### PR TITLE
Save file id, file name, and project code in usage log

### DIFF
--- a/BHoMAnalytics_Engine/Compute/SummariseUsageData.cs
+++ b/BHoMAnalytics_Engine/Compute/SummariseUsageData.cs
@@ -43,11 +43,13 @@ namespace BH.Engine.BHoMAnalytics
 
             List<UsageEntry> dbEntries = new List<UsageEntry>();
 
-            foreach (var uiGroup in logEntries.GroupBy(x => x.UI))
+            foreach (var fileGroup in logEntries.GroupBy(x => x.FileId))
             {
-                string ui = uiGroup.Key;
+                string fileId = fileGroup.Key;
+                string fileName = fileGroup.Select(x => x.FileName).Where(x => !string.IsNullOrEmpty(x)).FirstOrDefault();
+                string projectCode = fileGroup.Select(x => x.ProjectCode).Where(x => !string.IsNullOrEmpty(x)).FirstOrDefault();
 
-                foreach (var itemGroup in uiGroup.GroupBy(x => x.CallerName + x.SelectedItem))
+                foreach (var itemGroup in fileGroup.GroupBy(x => x.CallerName + x.SelectedItem))
                 {
                     UsageLogEntry firstEntry = itemGroup.First();
 
@@ -55,12 +57,15 @@ namespace BH.Engine.BHoMAnalytics
                     {
                         StartTime = itemGroup.Min(x => x.Time),
                         EndTime = itemGroup.Max(x => x.Time),
-                        UI = ui,
+                        UI = firstEntry.UI,
                         UiVersion = firstEntry.UiVersion,
                         CallerName = firstEntry.CallerName,
                         SelectedItem = firstEntry.SelectedItem,
                         Computer = computer,
                         BHoMVersion = firstEntry.BHoMVersion,
+                        FileId = fileId,
+                        FileName = fileName,
+                        ProjectCode = projectCode,
                         NbCallingComponents = itemGroup.Select(x => x.ComponentId).Distinct().Count(),
                         TotalNbCalls = itemGroup.Count(),
                         Errors = itemGroup.SelectMany(x => x.Errors).GroupBy(x => x.Message).Select(g => g.First()).ToList()

--- a/BHoMAnalytics_Engine/Compute/SummariseUsageData.cs
+++ b/BHoMAnalytics_Engine/Compute/SummariseUsageData.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.BHoMAnalytics
             {
                 string fileId = fileGroup.Key;
                 string fileName = fileGroup.Select(x => x.FileName).Where(x => !string.IsNullOrEmpty(x)).FirstOrDefault();
-                string projectCode = fileGroup.Select(x => x.ProjectCode).Where(x => !string.IsNullOrEmpty(x)).FirstOrDefault();
+                string projectID = fileGroup.Select(x => x.ProjectID).Where(x => !string.IsNullOrEmpty(x)).FirstOrDefault();
 
                 foreach (var itemGroup in fileGroup.GroupBy(x => x.CallerName + x.SelectedItem))
                 {
@@ -65,7 +65,7 @@ namespace BH.Engine.BHoMAnalytics
                         BHoMVersion = firstEntry.BHoMVersion,
                         FileId = fileId,
                         FileName = fileName,
-                        ProjectCode = projectCode,
+                        ProjectID = projectID,
                         NbCallingComponents = itemGroup.Select(x => x.ComponentId).Distinct().Count(),
                         TotalNbCalls = itemGroup.Count(),
                         Errors = itemGroup.SelectMany(x => x.Errors).GroupBy(x => x.Message).Select(g => g.First()).ToList()

--- a/BHoMAnalytics_oM/UsageEntry.cs
+++ b/BHoMAnalytics_oM/UsageEntry.cs
@@ -52,6 +52,12 @@ namespace BH.oM.BHoMAnalytics
 
         public virtual string BHoMVersion { get; set; } = "";
 
+        public virtual string FileId { get; set; } = "";
+
+        public virtual string FileName { get; set; } = "";
+
+        public virtual string ProjectCode { get; set; } = "";
+
         public virtual int NbCallingComponents { get; set; } = 0;
 
         public virtual int TotalNbCalls { get; set; } = 0;

--- a/BHoMAnalytics_oM/UsageEntry.cs
+++ b/BHoMAnalytics_oM/UsageEntry.cs
@@ -56,7 +56,7 @@ namespace BH.oM.BHoMAnalytics
 
         public virtual string FileName { get; set; } = "";
 
-        public virtual string ProjectCode { get; set; } = "";
+        public virtual string ProjectID { get; set; } = "";
 
         public virtual int NbCallingComponents { get; set; } = 0;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/2312
https://github.com/BHoM/BHoM_UI/pull/370
https://github.com/BHoM/Grasshopper_Toolkit/pull/604
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #15 

Provide changes required for fileName and project code to be saved by analytics. 



### Test files
- Create a script (or open an existing one) and add the `SetProjectCode` component with a non-empty string. Save it, run/create at least one component after the file has a name, and then close Rhino. 
- You should have a log file in `C:\ProgramData\BHoM\Logs`. Open it and make sure that file names and project code are available.
- Reopen Grasshopper. The data should now be in the BHoMAnalytics database. Only Al and I have access to that one but we can check that your entries appear correctly once you have done the rest of the test.

### Additional comments
Once we script has a file name, it is important that at least one component is ran before closing the whole thing. This is because there is currently no event detection for fileSaving. So the only way we have right now to keep a record of the fileName is through the components running. So the case where the file is saved for the first time and immediately closed after only records file id, not file name. I can add the file saving event later (one for each UI obviously) but it felt out of the scope of this PR as it is a fairly exceptional case. Let me know if you disagree.