### PR TITLE
Usage data collection crowbared not to log Revit usage in case of RevitAPI assembly not being loaded

### DIFF
--- a/BHoMAnalytics_Engine/Compute/CollectUsageData.cs
+++ b/BHoMAnalytics_Engine/Compute/CollectUsageData.cs
@@ -45,10 +45,14 @@ namespace BH.Engine.BHoMAnalytics
                 Engine.Reflection.Compute.RecordWarning("The folder C:\\ProgramData\\BHoM\\Logs doesn't exist so nothing was collected");
                 return new List<UsageEntry>();
             }
-                
-            List<UsageEntry> usageEntries = new List<UsageEntry>();
-
+            
             string[] usageFiles = Directory.GetFiles(logFolder, "Usage_*.log");
+
+            //TODO: this is a crowbar solution to disable pushing Revit logs to the database when not in Revit thread to avoid serialisation issues - to be improved
+            if (AppDomain.CurrentDomain.GetAssemblies().All(x => x.GetName().Name != "RevitAPI"))
+                usageFiles = usageFiles.Where(x => !x.Contains("Revit")).ToArray();
+
+            List<UsageEntry> usageEntries = new List<UsageEntry>();
             foreach (string file in usageFiles)
             {
                 // Get the file content


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #19

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
Please note that `if (AppDomain.CurrentDomain.GetAssemblies().All(x => x.GetName().Name != "RevitAPI"))` conditional could not be replaced with anything based on `System.Reflection.Assembly.GetExecutingAssembly()` because the latter returns `BHoMAnalytics_Adapter` assembly, which is caused by `SendUsageData` being called via Reflection.