### PR TITLE
Set Window Positions to Center Screen

### DIFF
--- a/BHoMAnalytics_UI/CaptureProjectData.xaml
+++ b/BHoMAnalytics_UI/CaptureProjectData.xaml
@@ -8,7 +8,7 @@
         Title="Confirm Project Data" Height="240" Width="350"
         ShowInTaskbar="False"
         ResizeMode="NoResize"
-        WindowStartupLocation="CenterOwner"
+        WindowStartupLocation="CenterScreen"
         Topmost="True"
         Deactivated="Deactivate_Window"
         MouseDown="Window_MouseDown"


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #39 

<!-- Add short description of what has been fixed -->
Window position set to `CenterScreen` to alleviate issues with window pop-up appearing in nonsensical locations. 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `CaptureProjectData.xaml` - Window position set to `CenterScreen` to alleviate issues with window pop-up appearing in nonsensical locations. 

### Additional comments
<!-- As required -->
@rboulton-BH  can you test this on your machine with multiple monitors and report back the results? I am only on my laptop today and the window does in fact appear at the center of my screen no matter the UI, but I would love to see how it behaves on multiple monitor setups. Please include a gif using [screentogif](https://www.screentogif.com/downloads) thanks!