### PR TITLE
Add username property to UsageEntry

### DIFF
--- a/BHoMAnalytics_Engine/Compute/SummariseUsageData.cs
+++ b/BHoMAnalytics_Engine/Compute/SummariseUsageData.cs
@@ -42,8 +42,6 @@ namespace BH.Engine.BHoMAnalytics
         [Output("usageEntries", "A list of summarised usage entries.")]
         public static List<UsageEntry> SummariseUsageData(this List<UsageLogEntry> logEntries)
         {
-            string computer = Environment.MachineName;
-
             List<UsageEntry> dbEntries = new List<UsageEntry>();
 
             foreach (var fileGroup in logEntries.GroupBy(x => x.FileId))
@@ -64,7 +62,8 @@ namespace BH.Engine.BHoMAnalytics
                         UiVersion = firstEntry.UiVersion,
                         CallerName = firstEntry.CallerName,
                         SelectedItem = firstEntry.SelectedItem,
-                        Computer = computer,
+                        Computer = Environment.MachineName,
+                        Username = Environment.UserName,
                         BHoMVersion = firstEntry.BHoMVersion,
                         FileId = fileId,
                         FileName = fileName,

--- a/BHoMAnalytics_oM/UsageEntry.cs
+++ b/BHoMAnalytics_oM/UsageEntry.cs
@@ -50,6 +50,8 @@ namespace BH.oM.BHoMAnalytics
 
         public virtual string Computer { get; set; } = "";
 
+        public virtual string Username { get; set; } = "";
+
         public virtual string BHoMVersion { get; set; } = "";
 
         public virtual string FileId { get; set; } = "";


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Fixes #85 

This adds the capture of the username on top of the computer ID.



### Test files
After compiling this code, make sure to use one of our BHoM UIs. This will generate new log files that will be pushed to our database.

To test that this worked, you can connect to the Mongo database to check that the entries are now containing your username.
The simplest Mongo query to check the result is `db.getCollection("UsageData").find({}).sort({_id: -1})` .
